### PR TITLE
set more sensible default values in metadata.yml

### DIFF
--- a/.template/metadata.yml
+++ b/.template/metadata.yml
@@ -12,10 +12,10 @@ breakurl: true
 link-citations: true
 
 Deckblatt: true
-toc: true
-lot: false
-lof: false
-glossaryafter: true
+toc: true             # table of contents
+lot: true             # list of tables
+lof: true             # list of figures
+glossaryafter: false  # put glossary at the end of the document
 
 natbib: true
 


### PR DESCRIPTION
- enabled LoF, LoT by default as some examiners expect them
- put the glossary to the beginning of the paper as this is the expected place of such