### PR TITLE
change the layout of the title page and structure of LoF, LoT and Glossary

### DIFF
--- a/.template/tex/packages.tex
+++ b/.template/tex/packages.tex
@@ -7,7 +7,7 @@
 \usepackage{tabularx}
 \usepackage{booktabs}
 
-\usepackage{glossaries}
+\usepackage[toc]{glossaries}
 
 \usepackage{subfigure}
 \usepackage{wrapfig}

--- a/.template/tex/packages.tex
+++ b/.template/tex/packages.tex
@@ -3,6 +3,7 @@
 \usepackage{siunitx}
 \usepackage{setspace}
 \usepackage{calc}
+\usepackage[figure,table]{totalcount}
 
 \usepackage{tabularx}
 \usepackage{booktabs}

--- a/.template/tex/template.tex
+++ b/.template/tex/template.tex
@@ -421,7 +421,8 @@ $if(Deckblatt)$
 \begin{center}
   \begin{tabularx}{\textwidth}{r|X}
     Modul & $module$ \\\midrule
-    Autor & $author$ \\\midrule
+    $if(author)$ Autor & $author$ $if(matriculation-number)$(Matrikel-Nr. $matriculation-number$)$endif$ \\\midrule
+    $else$ Matrikel-Nr. & $matriculation-number$ \\\midrule $endif$
     Studiengang, Zenturie & $course-of-studies$, $centuria$\
   \end{tabularx}
 \end{center}

--- a/.template/tex/template.tex
+++ b/.template/tex/template.tex
@@ -445,11 +445,6 @@ $for(include-before)$
 $include-before$
 $endfor$
 
-$if(glossaryafter)$
-$else$
-\printnoidxglossary[sort=word]
-$endif$
-
 $if(toc)$
 $if(toc-title)$
 \renewcommand*\contentsname{$toc-title$}
@@ -472,13 +467,17 @@ $endif$
 $endif$
 $endif$
 \pagebreak
-$if(lot)$
-\addcontentsline{toc}{section}{\listfigurename}
-\listoftables
-$endif$
 $if(lof)$
 \addcontentsline{toc}{section}{\listfigurename}
 \listoffigures
+$endif$
+$if(lot)$
+\addcontentsline{toc}{section}{\listtablename}
+\listoftables
+$endif$
+$if(glossaryafter)$
+$else$
+\printnoidxglossary[sort=word]
 $endif$
 \pagebreak
 \pagenumbering{arabic}

--- a/.template/tex/template.tex
+++ b/.template/tex/template.tex
@@ -469,12 +469,16 @@ $endif$
 $endif$
 \pagebreak
 $if(lof)$
-\addcontentsline{toc}{section}{\listfigurename}
-\listoffigures
+\iftotalfigures
+  \addcontentsline{toc}{section}{\listfigurename}
+  \listoffigures
+\fi
 $endif$
 $if(lot)$
-\addcontentsline{toc}{section}{\listtablename}
-\listoftables
+\iftotaltables
+  \addcontentsline{toc}{section}{\listtablename}
+  \listoftables
+\fi
 $endif$
 $if(glossaryafter)$
 $else$

--- a/.template/tex/template.tex
+++ b/.template/tex/template.tex
@@ -420,9 +420,9 @@ $if(Deckblatt)$
 
 \begin{center}
   \begin{tabularx}{\textwidth}{r|X}
-    Modul & $header-title$ \\\midrule
+    Modul & $module$ \\\midrule
     Autor & $author$ \\\midrule
-    Studiengang, Zenturie & $Studiengang$, $Zenturie$\
+    Studiengang, Zenturie & $course-of-studies$, $centuria$\
   \end{tabularx}
 \end{center}
 
@@ -437,7 +437,7 @@ $endif$
 
 \pagenumbering{roman}
 \pagestyle{fancy}
-\lhead{\textcolor{nordakademie-blue}{\uppercase{$header-title$}}}
+\lhead{\textcolor{nordakademie-blue}{\uppercase{$module$}}}
 \rhead{\textcolor{nordakademie-blue}{\includegraphics[height=1cm,keepaspectratio]{.template/logo_header.png}}}
 \cfoot{\thepage}
 

--- a/.template/tex/template.tex
+++ b/.template/tex/template.tex
@@ -406,22 +406,22 @@ $if(csl-refs)$
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
 
-\pagenumbering{roman}
 $if(Deckblatt)$
+\thispagestyle{empty}
 \begin{center}
   \includegraphics[width=0.4\textwidth,keepaspectratio]{.template/logo_centered.png}
   \vspace{2cm}
 \end{center}
 
 \begin{center}
-  {\huge $header-title$\par}
-  \vspace{1cm}
+  {\LARGE $title$\par}
+  \vspace{2cm}
 \end{center}
 
 \begin{center}
   \begin{tabularx}{\textwidth}{r|X}
-    Matrikelnummer & $Matrikelnummer$ \\\midrule
-    Thema & $title$ \\\midrule
+    Modul & $header-title$ \\\midrule
+    Autor & $author$ \\\midrule
     Studiengang, Zenturie & $Studiengang$, $Zenturie$\
   \end{tabularx}
 \end{center}
@@ -435,6 +435,7 @@ $endif$
 \pagebreak
 $endif$
 
+\pagenumbering{roman}
 \pagestyle{fancy}
 \lhead{\textcolor{nordakademie-blue}{\uppercase{$header-title$}}}
 \rhead{\textcolor{nordakademie-blue}{\includegraphics[height=1cm,keepaspectratio]{.template/logo_header.png}}}

--- a/src/01_introduction.md
+++ b/src/01_introduction.md
@@ -2,10 +2,10 @@
     header-title: Transferleistung 1
     title: Optimierung der Build-Dauer eines Web Application Bundler durch Anpassung der Konfiguration und dessen Auswirkung auf den Entwicklungsprozess
 
-    author: Max Mustermann
+    # For transfer papers only disclose your matriculation number
+    author: "Max Mustermann (Matrikel-Nr. 1337)"
     Zenturie: A22f
     Studiengang: Angewandte Informatik
-    Matrikelnummer: 1337
 
     keywords: [keyword1, keyword2]
     

--- a/src/01_introduction.md
+++ b/src/01_introduction.md
@@ -1,11 +1,11 @@
 ---
-    header-title: Transferleistung 1
+    module: Transferleistung 1
     title: Optimierung der Build-Dauer eines Web Application Bundler durch Anpassung der Konfiguration und dessen Auswirkung auf den Entwicklungsprozess
 
     # For transfer papers only disclose your matriculation number
     author: "Max Mustermann (Matrikel-Nr. 1337)"
-    Zenturie: A22f
-    Studiengang: Angewandte Informatik
+    centuria: A22f
+    course-of-studies: Angewandte Informatik
 
     keywords: [keyword1, keyword2]
     

--- a/src/01_introduction.md
+++ b/src/01_introduction.md
@@ -3,7 +3,7 @@
     title: Optimierung der Build-Dauer eines Web Application Bundler durch Anpassung der Konfiguration und dessen Auswirkung auf den Entwicklungsprozess
 
     # For transfer papers only disclose your matriculation number
-    author: "Max Mustermann (Matrikel-Nr. 1337)"
+    author: Max Mustermann (Matrikel-Nr. 1337)
     centuria: A22f
     course-of-studies: Angewandte Informatik
 

--- a/src/01_introduction.md
+++ b/src/01_introduction.md
@@ -2,8 +2,9 @@
     module: Transferleistung 1
     title: Optimierung der Build-Dauer eines Web Application Bundler durch Anpassung der Konfiguration und dessen Auswirkung auf den Entwicklungsprozess
 
-    # For transfer papers only disclose your matriculation number
-    author: Max Mustermann (Matrikel-Nr. 1337)
+    # For transfer papers leave author blank
+    author: Max Mustermann
+    matriculation-number: 1337
     centuria: A22f
     course-of-studies: Angewandte Informatik
 


### PR DESCRIPTION
- used topic of the paper as the main title
- renamed header-title variable to "module" (transfer papers are modules according to CIS and module handbook)
- changed all variables in frontmatter to use English language
- combined author and Matrikelnummer variable to one
- changed order of indexes as described [here](https://www.scribbr.de/aufbau-und-gliederung/das-glossar-einer-abschlussarbeit/#weitere-verzeichnisse-in-deiner-abschlussarbeit):
    1. ToC
    2. LoF
    3. LoT
    4. Glossary (if glossaryafter = false)
    5. Main Content
    6. Glossary (if glossaryafter = true)