### PR TITLE
add lua filter to translate image paths

### DIFF
--- a/.build/FlagsGeneral.txt
+++ b/.build/FlagsGeneral.txt
@@ -5,3 +5,4 @@
 --metadata-file=.template/metadata.yml
 --lua-filter=.template/pandoc/date.lua
 --lua-filter=.template/pandoc/gls.lua
+--lua-filter=.template/pandoc/imgpaths.lua

--- a/.template/pandoc/imgpaths.lua
+++ b/.template/pandoc/imgpaths.lua
@@ -1,0 +1,17 @@
+-- translating paths autocompleted by VS Code IntelliSense (relative to src/ or absolute (aka. relative to project root)) to relative paths to project root
+-- https://github.com/jgm/pandoc/issues/4894#issuecomment-612281355
+-- https://stackoverflow.com/questions/4990990/check-if-a-file-exists-with-lua
+
+function Image (img)
+    if img.src:sub(1,1) == '/' then
+        img.src = img.src:sub(2)
+    else
+        local f=io.open('src/' .. img.src, 'r')
+        if f~=nil then
+            io.close(f)
+            img.src  = "src/" .. img.src
+        end
+    end
+    return img
+end
+ 

--- a/src/01_introduction.md
+++ b/src/01_introduction.md
@@ -47,6 +47,10 @@ Saxa resoluta quid nupta, tremulis ore infelix
 amnis at tamque, **procul siquidem** in artis! Poma partes sponte, nam lux
 discedit gravi aequore nunc[@src:source1]. Diese Information findet man in @fig:example.
 
-![Beispiel Abbildung](src/images/example.jpeg){#fig:example}
+![Beispiel Abbildung (relativer Pfad zu Project Root)](src/images/example.jpeg){#fig:example}
+
+![Beispiel Abbildung (absoluter Pfad)](/src/images/example.jpeg){#fig:example1}
+
+![Beispiel Abbildung (relativer Pfad)](images/example.jpeg){#fig:example2}
 
 \pagebreak


### PR DESCRIPTION
VS Code / IntelliSense auto completes paths for file embeds. But only either relative to the current file or as a pseudo-absolute path (relative to project root).

This lua filter translates pseudo-absolute paths and paths relative to src/ to a path relative to project root, which pandoc can follow.