### PR TITLE
fix toc links pointing to wrong section

### DIFF
--- a/.template/tex/template.tex
+++ b/.template/tex/template.tex
@@ -470,14 +470,14 @@ $endif$
 \pagebreak
 $if(lof)$
 \iftotalfigures
-  \addcontentsline{toc}{section}{\listfigurename}
   \listoffigures
+  \addcontentsline{toc}{section}{\listfigurename}
 \fi
 $endif$
 $if(lot)$
 \iftotaltables
-  \addcontentsline{toc}{section}{\listtablename}
   \listoftables
+  \addcontentsline{toc}{section}{\listtablename}
 \fi
 $endif$
 $if(glossaryafter)$


### PR DESCRIPTION
Clickable Links for LoF and LoT in Table of Contents were refering to the wrong sections.

The \addcontentsline command was triggered before the new section was created.